### PR TITLE
Complex workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ file:
     $ ./manage.py workflow passthrough /home/steve/my_adiff.xml > out_adiff.xml
 
 
+*workflow* and *loaddata* commands can be made more verbose, using `LOGLEVEL`
+environment variable. Eg:
+
+    $ LOGLEVEL=DEBUG ./manage.py workflow passthrough /home/steve/my_adiff.xml > out_adiff.xml
+
+Available log levels are : *INFO*, *DEBUG*, *WARNING*, *ERROR* and *CRITICAL*. Default is **INFO**.
+
 ### Loading data
 
 You may want to load data into the DB without applying an entire workflow.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ file:
     $ ./manage.py workflow passthrough /home/steve/my_adiff.xml > out_adiff.xml
 
 
+Alternatively, you can mention `--output-paths` :
+
+    $ ./manage.py workflow passthrough /home/steve/my_adiff.xml --output-paths out_adiff.xml
+
 *workflow* and *loaddata* commands can be made more verbose, using `LOGLEVEL`
 environment variable. Eg:
 

--- a/README.md
+++ b/README.md
@@ -103,22 +103,27 @@ You can have different workflows, configured in settings. By default, you only
 have one available called `passthrough` (basically useless) ; you can run it on
 some adiff file of yours:
 
-    $ ./manage.py workflow passthrough /home/steve/my_adiff.xml
+    $ ./manage.py workflow passthrough \
+        --input-paths /home/steve/my_adiff.xml
 
 It will output adiff XML code to stdout ; you may want to redirect it to some
 file:
 
-    $ ./manage.py workflow passthrough /home/steve/my_adiff.xml > out_adiff.xml
+    $ ./manage.py workflow passthrough --input-paths
+        /home/steve/my_adiff.xml > out_adiff.xml
 
 
 Alternatively, you can mention `--output-paths` :
 
-    $ ./manage.py workflow passthrough /home/steve/my_adiff.xml --output-paths out_adiff.xml
+    $ ./manage.py workflow passthrough
+        --input-paths /home/steve/my_adiff.xml \
+        --output-paths out_adiff.xml
 
 *workflow* and *loaddata* commands can be made more verbose, using `LOGLEVEL`
 environment variable. Eg:
 
-    $ LOGLEVEL=DEBUG ./manage.py workflow passthrough /home/steve/my_adiff.xml > out_adiff.xml
+    $ LOGLEVEL=DEBUG ./manage.py workflow passthrough \
+        --input-paths /home/steve/my_adiff.xml > out_adiff.xml
 
 Available log levels are : *INFO*, *DEBUG*, *WARNING*, *ERROR* and *CRITICAL*. Default is **INFO**.
 
@@ -254,4 +259,4 @@ something like:
 
 Bash to the rescue (example) :
 
-    $ for f in /home/steve/*.osm; do ./manage.py workflow passthrough "$f" > "/tmp/`basename -s.osm ${f}`.adiff" ; done
+    $ for f in /home/steve/*.osm; do ./manage.py workflow passthrough --input-paths "$f" --ouptput-paths "/tmp/`basename -s.osm ${f}`.adiff" ; done

--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ Osmada − OpenStreetMap Augmented Diff Analyzer
 
 Introduction
 ------------
-Osmada is a component to help monitor changes to OSM data. Unlike most QA Tools that are 
+Osmada is a component to help monitor changes to OSM data. Unlike most QA Tools that are
 based on monitoring changesets, OSMADA is designed to help monitor changes to data you're
-interested in, for instance the shops and restaurants of your city. 
+interested in, for instance the shops and restaurants of your city.
 
-Osmada reads and analyzes the result of 
+Osmada reads and analyzes the result of
 [Overpass Augmented Diff](https://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs) (*adiff*)
-requests in a database, it can then apply filters on those diffs and export the filtered diffs in various 
-formats. The intention is to filter out changes one wants to ignore and produce a report with 
+requests in a database, it can then apply filters on those diffs and export the filtered diffs in various
+formats. The intention is to filter out changes one wants to ignore and produce a report with
 the significant changes. This report can then be used by a mapper to check individual changes.
 
 An Augmented diff request produces an XML response composed of `<action>` elements. There are 3 types
-of actions : create, modify, delete. Each action contains two elements, the `<old>` and the `<new>` 
+of actions : create, modify, delete. Each action contains two elements, the `<old>` and the `<new>`
 versions of the same OSM object. Osmada analyzes those changes, loads them in a database and augments
-each change with information such as main tags, added and modified tags. Osmada can then filter the 
+each change with information such as main tags, added and modified tags. Osmada can then filter the
 changes, and export the filtered changes in the same format or a different one.
-    
+
 Osmada is designed to be used in workflows, typically composed of 3 steps :
 1. Load the changes in a database (SpatiaLite)
 2. Filter changes, for instance to ignore changes from trusted users or changes to unsignificant tags

--- a/osmada/base_settings.py
+++ b/osmada/base_settings.py
@@ -134,10 +134,12 @@ STATIC_URL = '/static/'
 
 TAGS_IMPORTANCE = ['highway=*', 'railway=*', 'shop=*', 'name=*']
 
-WORKFLOWS = {
-    'passthrough': {
-        'import': 'osmdata.importers.AdiffImporter',
-        'export' : 'osmdata.exporters.AdiffExporter',
-        'filters': [],
-    }
-}
+WORKFLOWS = [
+    {
+        'name': 'test_passthrough_adiff',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+            {'type': 'export', 'class': 'osmdata.exporters.AdiffExporter'},
+        ],
+    },
+]

--- a/osmada/base_settings.py
+++ b/osmada/base_settings.py
@@ -131,6 +131,33 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': os.environ.get('LOGLEVEL', 'INFO'),
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        },
+    },
+    'loggers': {
+        'workflows': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+        'osmdata': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+
+    },
+}
 
 TAGS_IMPORTANCE = ['highway=*', 'railway=*', 'shop=*', 'name=*']
 

--- a/osmada/local_settings.py.example
+++ b/osmada/local_settings.py.example
@@ -110,6 +110,15 @@ WORKFLOWS = [
             {'type': 'export', 'class': 'osmdata.exporters.AdiffExporter'}
         ],
     },
+    'name': 'test_multiple_outputs',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': [TRUSTED_USERS]} ,
+            {'type': 'export', 'class': 'osmdata.exporters.AdiffExporter'}
+            {'type': 'export', 'class': 'osmdata.exporters.AnalyzedCSVExporter'}
+        ],
+    },
     {
         'name': 'test_passthrough_adiff',
         'flow': [

--- a/osmada/local_settings.py.example
+++ b/osmada/local_settings.py.example
@@ -27,19 +27,29 @@ IGNORED_KEYS = ['note', 'description']
 
 # WORKFLOWS
 #
-# The core setting :workflow definitions, as a dict.
+# The core setting :workflow definitions, as a list
 #
-# Keys of the dict are a name you choose, they are later used to select your
-# workflow you call from CLI (see workflow command)
+# Each list item represents one workflow definition.
 #
-# Each value of the dict is a workflow definition with several fields
+# A workflow definition is a dict with two keys
 #
-# **import**
-# Dotted path to an importer class. Available importers are:
+# - 'flow', which is a list of steps, each step being a dict with
+#    3 keys :
+#     - type: the importer class (as dotted path str)
+#     - class: theexecutable class (as dotted path str). It can either
+#       relate to a Filter, an Importer or an Exporter, see below for full list.
+#     - params : a list of parameters
+#       passed to the Exporter/Importer/Filter
+# - 'name', which is the name of your workflow
+#
+# The order of the list in `flow` matters : it gives the execution order.
+#
+# Available classes for `class` key of step item
+#
+# Type `import`:
 # - AdiffImporter
 #
-# **export**
-# Dotted path to an exporter class. Available exporters are:
+# Type `export`:
 # - AdiffExporter
 # - CSVExporter
 # - AnalyzedCSVExporter ; it includes more fields requiring some analysis :
@@ -48,54 +58,63 @@ IGNORED_KEYS = ['note', 'description']
 #   - removed_tags: tags removed by action
 #   - modified_tags: tags which value was changed by action
 #
-# **filters***
-# A list of couples repsenting filter to run on imported data in order to filter out some actions
-# from the diff.
-# eatch item from `filters` list is a couple:
-#
-# 1. dotted path to a filter class
-# 2. a list of parameters to pass to the filter
-#
-WORKFLOWS = {
-    'test_simple_csv': {
-        'import': 'osmdata.importers.AdiffImporter',
-        'export' : 'osmdata.exporters.CSVExporter',
-        'filters': [
-            ('osmdata.filters.IgnoreUsers', [TRUSTED_USERS]),
-            ('osmdata.filters.IgnoreNewTags', ['amenity=wastebasket']),
-            ('osmdata.filters.IgnoreElementsModification', ['highway=crossing']),
-            ('osmdata.filters.IgnoreNewTags', ['wikidata=*']),
-            ('osmdata.filters.IgnoreElementsModification', ['note=*']),
-            ('osmdata.filters.IgnoreKeys', [IGNORED_KEYS]),
-        ]
+# Type `filter`:
+# - IgnoreUsers
+# - IgnoreElementsCreation
+# - IgnoreElementsModification
+# - IgnoreKeys
+# - IgnoreSmallNodeMoves
+
+WORKFLOWS = [
+    {
+        'name': 'test_simple_csv',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': [TRUSTED_USERS]} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['amenity=wastebasket']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['highway=crossing']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['wikidata=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['note=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreKeys', 'params': [IGNORED_KEYS]} ,
+
+
+            {'type': 'export', 'class': 'osmdata.exporters.CSVExporter'}
+        ],
     },
-    'test_advanced_csv': {
-        'import': 'osmdata.importers.AdiffImporter',
-        'export' : 'diffanalysis.exporters.AnalyzedCSVExporter',
-        'filters': [
-            ('osmdata.filters.IgnoreUsers', [TRUSTED_USERS]),
-            ('osmdata.filters.IgnoreNewTags', ['amenity=wastebasket']),
-            ('osmdata.filters.IgnoreElementsModification', ['highway=crossing']),
-            ('osmdata.filters.IgnoreNewTags', ['wikidata=*']),
-            ('osmdata.filters.IgnoreElementsModification', ['note=*']),
-            ('osmdata.filters.IgnoreKeys', [IGNORED_KEYS]),
-        ]
+    {
+        'name': 'test_advanced_csv',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': [TRUSTED_USERS]} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['amenity=wastebasket']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['highway=crossing']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['wikidata=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['note=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreKeys', 'params': [IGNORED_KEYS]} ,
+            {'type': 'export', 'class': 'osmdata.exporters.AnalyzedCSVExporter'}
+        ],
     },
-    'test_advanced_adiff': {
-        'import': 'osmdata.importers.AdiffImporter',
-        'export' : 'osmdata.exporters.AdiffExporter',
-        'filters': [
-            ('osmdata.filters.IgnoreUsers', [TRUSTED_USERS]),
-            ('osmdata.filters.IgnoreNewTags', ['amenity=wastebasket']),
-            ('osmdata.filters.IgnoreElementsModification', ['highway=crossing']),
-            ('osmdata.filters.IgnoreNewTags', ['wikidata=*']),
-            ('osmdata.filters.IgnoreElementsModification', ['note=*']),
-            ('osmdata.filters.IgnoreKeys', [IGNORED_KEYS]),
-        ]
+    {
+        'name': 'test_advanced_adiff',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': [TRUSTED_USERS]} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['amenity=wastebasket']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['highway=crossing']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['wikidata=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['note=*']} ,
+            {'type': 'filter', 'class': 'osmdata.filters.IgnoreKeys', 'params': [IGNORED_KEYS]} ,
+            {'type': 'export', 'class': 'osmdata.exporters.AdiffExporter'}
+        ],
     },
-    'passthrough': {
-        'import': 'osmdata.importers.AdiffImporter',
-        'export' : 'osmdata.exporters.AdiffExporter',
-        'filters': [],
-    }
-}
+    {
+        'name': 'test_passthrough_adiff',
+        'flow': [
+            {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+            {'type': 'export', 'class': 'osmdata.exporters.AdiffExporter'}
+        ],
+    },
+]

--- a/osmdata/importers.py
+++ b/osmdata/importers.py
@@ -2,18 +2,16 @@ from xml.dom.minidom import parse
 
 from .parsers import AdiffParser, FileFormatError
 
+
 class ImporterError(Exception):
     pass
 
-class AbstractImporter:  # pragma: no cover
-    def __init__(self, path):
-        """
-        :param path: a path to fetch the resource (URL, file path…)
-        """
-        raise NotImplemented
 
-    def run(self):
+class AbstractImporter:  # pragma: no cover
+    def run(self, path):
         """ Blocking function processing the import
+
+        :param path: a path to fetch the resource (URL, file path…)
         :rtype: .models.Diff
         """
         raise NotImplemented
@@ -25,10 +23,8 @@ class AdiffImporter(AbstractImporter):
     See https://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs
     """
 
-    def __init__(self, path):
+    def run(self, path):
         self.path = path
-
-    def run(self):
         try:
             dom = parse(self.path)
         except OSError as e:

--- a/osmdata/management/commands/import_adiff.py
+++ b/osmdata/management/commands/import_adiff.py
@@ -14,8 +14,8 @@ class Command(BaseCommand):
 
     def handle(self, adiff_path, *args, **options):
         try:
-            importer = AdiffImporter(adiff_path)
-            diff = importer.run()
+            importer = AdiffImporter()
+            diff = importer.run(adiff_path)
         except ImporterError as e:
             raise CommandError(e)
 

--- a/osmdata/management/commands/import_adiff.py
+++ b/osmdata/management/commands/import_adiff.py
@@ -1,8 +1,10 @@
+import logging
+
 from django.core.management.base import BaseCommand, CommandError
 
 from ...importers import AdiffImporter, ImporterError
 
-DEBUG = True
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -19,4 +21,6 @@ class Command(BaseCommand):
         except ImporterError as e:
             raise CommandError(e)
 
-        print('Created {} containing {} actions.'.format(diff, diff.actions.count()))
+        logger.info(
+            'Created {} containing {} actions.'.format(
+                diff, diff.actions.count()))

--- a/osmdata/tests/test_importers.py
+++ b/osmdata/tests/test_importers.py
@@ -15,20 +15,20 @@ class ImporterTests(TestCase):
 
     def test_open_nonexistent_file(self):
         with self.assertRaises(ImporterError):
-            importer = AdiffImporter('/tmp/do-not-exist-1234')
-            importer.run()
+            importer = AdiffImporter()
+            importer.run('/tmp/do-not-exist-1234')
 
     def test_open_valid_file(self):
-        importer = AdiffImporter(get_test_file_path('create_action.osm'))
+        importer = AdiffImporter()
         # We barely check there is no error
-        self.assertIsNotNone(importer.run())
+        self.assertIsNotNone(importer.run(get_test_file_path('create_action.osm')))
 
     def test_open_inexistant_file(self):
         with self.assertRaises(ImporterError):
-            importer = AdiffImporter(get_test_file_path('i-do-not-exist.osm'))
-            importer.run()
+            importer = AdiffImporter()
+            importer.run(get_test_file_path('i-do-not-exist.osm'))
 
     def test_open_invalid_data_file(self):
         with self.assertRaises(ImporterError):
-            importer = AdiffImporter(get_test_file_path('invalid_action.osm'))
-            importer.run()
+            importer = AdiffImporter()
+            importer.run(get_test_file_path('invalid_action.osm'))

--- a/workflows/models.py
+++ b/workflows/models.py
@@ -2,74 +2,83 @@ from django.utils.module_loading import import_string
 
 
 from diffanalysis.models import ActionReport
+from osmdata.models import Action
 from osmdata.patchers import FixRemoveOperationMetadata
 
 
+class Step:
+    STEP_FILTER = 'filter'
+    STEP_IMPORT = 'import'
+    STEP_EXPORT = 'export'
+
+    STEP_TYPES = [STEP_FILTER, STEP_IMPORT, STEP_EXPORT]
+
+    def __init__(self, step_type, step_class, step_params):
+        if step_type not in self.STEP_TYPES:
+            raise ValueError('Unknown step type : {}'.format(step_type))
+        self.type = step_type
+        self.instance = step_class(*step_params)
+
+
 class WorkFlow:
-    """ Complete Import-Filter-Export cycle
+    """Complete Import-Filter-Export cycle
 
-    a WorkFlow instance holds all the step and internal state for a diff
-    processing. steps are :
+    A workflow instance holds a succession of several of those steps, in any
+    order :
 
-    1. Load diff data from an external source into DB.
-    2. Apply one or several filters
-    3. Output as string in a given format
-
+    - import (from files)
+    - export in some format (to file or to stdout)
+    - filtering (non destructive, data is always kept, but not handed to the
+      next step(s))
     """
 
-    def __init__(self, name, importer, exporter):
+    def __init__(self, name, steps):
         self.name = name
-        self.ImporterClass = importer
-        self.ExporterClass = exporter
-        self.filters = []
+        self.steps = steps
         self.diff = None
 
-    def add_filter(self, _filter):
-        """
-        :param _filter: the filter instance
-        """
-        self.filters.append(_filter)
+    def run(self, path):
+        qs = Action.objects.none()
+        diff = None
+        self.last_step_output = None
 
-    def run_import(self, path):
-        """ Import an external resource into db using the importer
+        for step in self.steps:
+            logger.debug('Running step {}'.format(step.instance))
+            if step.type == step.STEP_IMPORT:
+                diff = step.instance.run(path)
+                # every import step overwrite any previous qs :
+                qs = diff.actions
+                self.last_step_output = qs
+                for patch_name in self.apply_data_patches(qs):
+                    pass # FIXME
 
-        The `path` nature depends on the importer class.
-        :param path: the path (file path, url…) to fetch
-        :return: the created diff model instance
-        :rtype: Diff
-        """
-        importer = self.ImporterClass(path)
-        self.diff = importer.run()
-        return self.diff
+                self.make_action_reports(qs)
 
-    def make_action_reports(self):
+            elif step.type == step.STEP_EXPORT:
+                # output file content is first stored in memory,
+                # as a string
+                output = step.instance.run(qs)
+                self.last_step_output = output
+                print(output)
+            elif step.type == step.STEP_FILTER:
+                qs = step.instance.filter(qs)
+                self.last_step_output = qs
+
+    def make_action_reports(self, qs):
         """ Make an ActionReport for each Action of the queryset
 
         This operation is costly, but the result might be used by some
         filters.
+
+        :type qs: an Action QuerySet
         """
-        for action in self.diff.actions.all():
+        for action in qs.all():
             ActionReport.objects.get_or_create_for_action(action)
 
-    def iter_filters(self):
-        """ Iteratively apply filters on diff
-
-        :yield: filter obj and queryset at each iteration
-        """
-        if self.diff is None:
-            raise ValueError("You should import data first")
-
-        self.out_qs = self.diff.actions.select_related('report')
-        for _filter in self.filters:
-            self.out_qs = _filter.filter(self.out_qs)
-            yield _filter, self.out_qs
-
-    def write_output(self):
-        return self.ExporterClass().run(self.out_qs)
-
-    def apply_data_patches(self):
+    def apply_data_patches(self, qs):
         """ That step modifies the data in database
 
+        :type qs: an Action QuerySet
         This is mainly intended for workarounds
         """
         # Make it configurable ?
@@ -77,48 +86,72 @@ class WorkFlow:
         for PatchClass in patches:
             patch = PatchClass()
             yield patch.description
-            patch.patch(self.diff.actions)
+            patch.patch(qs)
 
     @classmethod
     def from_settings(cls, name, spec):
-        """
-        Use a setting spec dict to configure a workflow.
+        """Use a setting spec dict to configure a workflow.
 
-        The setting_spec dict requires the following fields :
-          - import: the importer class (as dotted path str)
-          - export: the exporter class (as dotted path str)
-          - filters: a list of filter spec
+        The setting_spec dict require only two keys :
 
-        The filter spec is a 2-uplet :
-          1. the filter class (as dotted path str)
-          2. an optional list of argument to be passed to the filter
-          constructor
+
+        - 'flow', which is a list of steps, each step being a dict with
+           3 keys :
+            - type: the importer class (as dotted path str)
+            - class: theexecutable class (as dotted path str). It can either
+              relate to a Filter, an Importer or an Exporter)
+            - params : a list of parameters
+              passed to the Exporter/Importer/Filter
+        - 'name', which is the name of your workflow
+
+        The order of the list matters (execution order)
 
         Ex of setting spec:
         {
-          'import': 'osmdata.importers.AdiffImporter',
-          'export' : 'osmdata.exporters.CSVExporter',
-          'filters': [
-            ('osmdata.filters.IgnoreUsers', [['jm']]),
-            ('osmdata.filters.IgnoreElementsCreation', ['amenity=waterbasket']),
-            ('osmdata.filters.IgnoreElementsModification', ['amenity=waterbasket']),
+            'name': 'my-wf',
+            'flow': [
+                {'type': 'import', 'class', 'osmdata.importers.AdiffImporter'},
+                {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': ['jm']} ,
+                {'type': 'filter', 'class': 'osmdata.filters.IgnomeElementsCreation', 'params': ['amenity=wastebasket']} ,
+                {'type': 'filter', 'class': 'osmdata.filters.IgnomeElementsModification', 'params': ['amenity=wastebasket']} ,
+                {'type': 'export': 'class': 'osmdata.exporters.CSVExporter'}
+            ]
         }
 
         :param name: The workflow name you choose
         :param setting_spec: a dict specifying the workflow spec (see above).
         :rtype: Diff
+
         """
-        try:
-            ImporterClass = import_string(spec['import'])
-            ExporterClass = import_string(spec['export'])
-        except KeyError:
+
+        if 'flow' not in spec or 'name' not in spec:
             raise ValueError(
-                '"import" and "export" keys are required in workflow spec.')
+                '"flow" and "name" keys are required in workflow spec.')
+        else:
+            for key in spec:
+                if key not in ('flow', 'name'):
+                    raise ValueError('Unknown key : "{}"'.format(key))
 
-        workflow = cls(name, ImporterClass, ExporterClass)
 
-        for klass_path, args in spec.get('filters', []):
-            Klass = import_string(klass_path)
-            workflow.add_filter(Klass(*args))
+        name = name
+        steps = []
+
+        for step in spec['flow']:
+            for i in step.keys():
+                if i not in ['type', 'class', 'params']:
+                    raise ValueError('Unknown key : {}'.format(i))
+            try:
+                step_type = step['type']
+                step_class = import_string(step['class'])
+            except KeyError:
+                raise ValueError(
+                    '"class" and "type" are required keys for each flow step')
+            except ImportError:
+                raise ValueError('{} does not exist'.format(step['class']))
+            step_params = step.get('params', [])
+
+            steps.append(Step(step_type, step_class, step_params))
+
+        workflow = cls(name=name, steps=steps)
 
         return workflow

--- a/workflows/models.py
+++ b/workflows/models.py
@@ -1,9 +1,13 @@
+import logging
+
 from django.utils.module_loading import import_string
 
 
 from diffanalysis.models import ActionReport
 from osmdata.models import Action
 from osmdata.patchers import FixRemoveOperationMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class Step:
@@ -50,7 +54,7 @@ class WorkFlow:
                 qs = diff.actions
                 self.last_step_output = qs
                 for patch_name in self.apply_data_patches(qs):
-                    pass # FIXME
+                    logger.debug('Applying data patch {}'.format(patch_name))
 
                 self.make_action_reports(qs)
 

--- a/workflows/tests.py
+++ b/workflows/tests.py
@@ -8,7 +8,7 @@ from osmdata.exporters import CSVExporter
 from osmdata.models import Diff
 from osmdata.tests.utils import get_test_file_path
 
-from .models import WorkFlow
+from .models import Step, WorkFlow
 
 class TestWorkFlow(TestCase):
     fixtures = ['test_filters.json']  # Versailles Chantier
@@ -22,73 +22,74 @@ class TestWorkFlow(TestCase):
                     ('osmdata.filters.IgnoreElementsCreation', ['amenity=waterbasket']),
                     ('osmdata.filters.IgnoreElementsModification', ['amenity=waterbasket']),
                 ]
+        } # TO BE DELETED
+        ok_workflow = {
+            'name': 'test-wf',
+            'flow': [
+                {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
+                {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': ['jm']} ,
+                {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['amenity=wastebasket']} ,
+                {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['amenity=wastebasket']} ,
+                {'type': 'export', 'class': 'osmdata.exporters.CSVExporter'}
+            ]
         }
         wf = WorkFlow.from_settings('gare_standard', ok_workflow)
 
         self.assertEqual(wf.name, 'gare_standard')
-        self.assertEqual(wf.ImporterClass, AdiffImporter)
-        self.assertEqual(wf.ExporterClass, CSVExporter)
-        self.assertEqual(len(wf.filters), 3)
-        self.assertIsInstance(wf.filters[0], IgnoreUsers)
-        self.assertIsInstance(wf.filters[1], IgnoreElementsCreation)
-        self.assertIsInstance(wf.filters[2], IgnoreElementsModification)
+        self.assertEqual(len(wf.steps), 5)
+        self.assertIsInstance(wf.steps[0].instance, AdiffImporter)
+        self.assertIsInstance(wf.steps[1].instance, IgnoreUsers)
+        self.assertIsInstance(wf.steps[2].instance, IgnoreElementsCreation)
+        self.assertIsInstance(wf.steps[3].instance, IgnoreElementsModification)
+        self.assertIsInstance(wf.steps[4].instance, CSVExporter)
 
     def test_invalid_workflow_from_settings(self):
-        missing_export = {'import': 'osmdata.importers.AdiffImporter'}
-        missing_import = {'export' : 'osmdata.exporters.CSVExporter'}
-        with self.assertRaises(ValueError):
-            WorkFlow.from_settings('a', missing_export)
-        with self.assertRaises(ValueError):
-            WorkFlow.from_settings('a', missing_import)
+        with self.assertRaises(ValueError, msg='missing name'):
+            WorkFlow.from_settings('a', {'flow': []})
+
+        with self.assertRaises(ValueError, msg='missing flow'):
+            WorkFlow.from_settings('a', {'name': 'foo'})
+
+        with self.assertRaises(ValueError, msg='unknown key'):
+            WorkFlow.from_settings('a', {
+                'name': 'foo', 'flow': [], 'bar': 'zut'
+            })
+
+        with self.assertRaises(ValueError, msg='wrong step type'):
+            WorkFlow.from_settings('a', {
+                'name': 'foo', 'flow': [
+                    {'type': 'zut', 'class': 'osmdata.exporters.CSVExporter'},
+                ]
+            })
+
+        with self.assertRaises(ValueError, msg='inexistant step class'):
+            WorkFlow.from_settings('a', {
+                'name': 'foo',
+                'flow': [{'type': 'exporter', 'class': 'osmdata.exporters.No'}]
+            })
+
+    def test_run_empty(self):
+        wf = WorkFlow(
+            name='test',
+            steps=[]
+        )
+        wf.run(get_test_file_path('create_action.osm'))
 
     def test_run_import(self):
         wf = WorkFlow(
             name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=osmdata.exporters.CSVExporter)
-
-        wf.run_import(get_test_file_path('create_action.osm'))
-
-    def test_iter_filters_w_filter(self):
-        # pretty stupid : it keeps the first
-        class _KeepFirstFilter(AbstractActionFilter):
-            def __init__(self):
-                pass
-
-            def filter(self, qs):
-                return qs.all()[:1]
-
-        wf = WorkFlow(
-            name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=osmdata.exporters.CSVExporter,
-
+            steps=[
+                Step(Step.STEP_IMPORT, osmdata.importers.AdiffImporter, [])
+            ]
         )
-        wf.filters = [_KeepFirstFilter()]
-        wf.diff = Diff.objects.first()
-        result = list(wf.iter_filters())
-        self.assertEqual(len(result), 1)
-        self.assertIsInstance(result[0][0], _KeepFirstFilter)
-        self.assertEqual(list(result[0][1]), list(wf.diff.actions.all()[:1]))
+        self.assertEqual(Diff.objects.count(), 1)
+        self.assertEqual(ActionReport.objects.count(), 0)
 
+        wf.run(get_test_file_path('create_action.osm'))
 
-    def test_iter_filters_wo_filter(self):
-        wf = WorkFlow(
-            name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=osmdata.exporters.CSVExporter)
-        wf.diff = Diff.objects.first()
-        result = list(wf.iter_filters())
-        self.assertEqual(result, [])
-
-    def test_iter_filters_wo_diff(self):
-        wf = WorkFlow(
-            name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=osmdata.exporters.CSVExporter)
-
-        with self.assertRaises(ValueError):
-            list(wf.iter_filters())
+        self.assertEqual(Diff.objects.count(), 2)
+        # Check that action reports have been made
+        self.assertEqual(ActionReport.objects.count(), 1)
 
     def test_output(self):
         class _CounterExporter:
@@ -97,21 +98,33 @@ class TestWorkFlow(TestCase):
 
         wf = WorkFlow(
             name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=_CounterExporter)
+            steps=[
+                Step(Step.STEP_IMPORT, osmdata.importers.AdiffImporter, []),
+                Step(Step.STEP_EXPORT, _CounterExporter, [])
+            ]
+        )
+        wf.run(get_test_file_path('create_action.osm'))
+        self.assertEqual(wf.last_step_output, 1)
 
-        wf.diff = Diff.objects.first()
-        wf.out_qs = wf.diff.actions
-
-        self.assertEqual(wf.write_output(), 1)
-
-    def test_make_actionreports(self):
+    def test_filter_filter_in(self):
         wf = WorkFlow(
             name='test',
-            importer=osmdata.importers.AdiffImporter,
-            exporter=osmdata.exporters.CSVExporter)
+            steps=[
+                Step(Step.STEP_IMPORT, osmdata.importers.AdiffImporter, []),
+                Step(Step.STEP_FILTER, osmdata.filters.IgnoreUsers,
+                     [["DoNotExist"]])
+            ]
+        )
+        wf.run(get_test_file_path('create_action.osm'))
+        self.assertEqual(wf.last_step_output.count(), 1)
 
-        wf.diff = Diff.objects.first()
-        wf.make_action_reports()
-
-        self.assertEqual(ActionReport.objects.count(), wf.diff.actions.count())
+    def test_filter_filter_out(self):
+        wf = WorkFlow(
+            name='test',
+            steps=[
+                Step(Step.STEP_IMPORT, osmdata.importers.AdiffImporter, []),
+                Step(Step.STEP_FILTER, osmdata.filters.IgnoreUsers, [["Yann_L"]])
+            ]
+        )
+        wf.run(get_test_file_path('create_action.osm'))
+        self.assertEqual(wf.last_step_output.count(), 0)

--- a/workflows/tests.py
+++ b/workflows/tests.py
@@ -73,7 +73,7 @@ class TestWorkFlow(TestCase):
             name='test',
             steps=[]
         )
-        wf.run(get_test_file_path('create_action.osm'))
+        wf.run([get_test_file_path('create_action.osm')], ['/dev/null'])
 
     def test_run_import(self):
         wf = WorkFlow(
@@ -85,7 +85,7 @@ class TestWorkFlow(TestCase):
         self.assertEqual(Diff.objects.count(), 1)
         self.assertEqual(ActionReport.objects.count(), 0)
 
-        wf.run(get_test_file_path('create_action.osm'))
+        wf.run([get_test_file_path('create_action.osm')], ['/dev/null'])
 
         self.assertEqual(Diff.objects.count(), 2)
         # Check that action reports have been made
@@ -103,7 +103,7 @@ class TestWorkFlow(TestCase):
                 Step(Step.STEP_EXPORT, _CounterExporter, [])
             ]
         )
-        wf.run(get_test_file_path('create_action.osm'))
+        wf.run([get_test_file_path('create_action.osm')], ['/dev/null'])
         self.assertEqual(wf.last_step_output, 1)
 
     def test_filter_filter_in(self):
@@ -115,7 +115,7 @@ class TestWorkFlow(TestCase):
                      [["DoNotExist"]])
             ]
         )
-        wf.run(get_test_file_path('create_action.osm'))
+        wf.run([get_test_file_path('create_action.osm')], ['/dev/null'])
         self.assertEqual(wf.last_step_output.count(), 1)
 
     def test_filter_filter_out(self):
@@ -126,5 +126,5 @@ class TestWorkFlow(TestCase):
                 Step(Step.STEP_FILTER, osmdata.filters.IgnoreUsers, [["Yann_L"]])
             ]
         )
-        wf.run(get_test_file_path('create_action.osm'))
+        wf.run([get_test_file_path('create_action.osm')], ['/dev/null'])
         self.assertEqual(wf.last_step_output.count(), 0)


### PR DESCRIPTION
Relates #7 

It is a work-in-progress, but I already decided how the workflow specification would look like : 

instead of 

```python
WORKFLOWS = {
        'my-workflow' : {
                'import': 'osmdata.importers.AdiffImporter',
                'export' : 'osmdata.exporters.CSVExporter',
                'filters': [
                    ('osmdata.filters.IgnoreUsers', [['jm']]),
                    ('osmdata.filters.IgnoreElementsCreation', ['amenity=waterbasket']),
                    ('osmdata.filters.IgnoreElementsModification', ['amenity=waterbasket']),
                ]
        }
}
```
We would have

```python
WORKFLOWS = [
        {
            'name': 'my-workflow',
            'flow': [
                {'type': 'import', 'class': 'osmdata.importers.AdiffImporter'},
                {'type': 'filter', 'class': 'osmdata.filters.IgnoreUsers', 'params': ['jm']} ,
                {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsCreation', 'params': ['amenity=wastebasket']} ,
                {'type': 'filter', 'class': 'osmdata.filters.IgnoreElementsModification', 'params': ['amenity=wastebasket']} ,
                {'type': 'export', 'class': 'osmdata.exporters.CSVExporter'}
            ]
        }
]
```

It allows to be totally free in import/export/filters order, which enables #7 requirement to be able to export several times, in the same workflow, either the same data or different data.


@naomap @Stefal @charlesmillet What do you think ?

(I will make that change backward incompatible, as there is currently only one known deployment ;-)